### PR TITLE
Add class format output

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,65 +1,69 @@
 (function(){
-  function declare(module_name, exports) {
-    if (module) module.exports = exports
-    else window[module_name] = exports
+  var declare = function declare (module_name, exports) {
+    if (module) module.exports = exports;
+    else window[module_name] = exports;
   }
 
-  function ansi2html(str) {
-    var props = {}
-      , open = false
+  var ansi2html = function ansi2html (str) {
+    this.props = {};
+    this.open = false;
+    this.str = str;
+  };
+  
+  ansi2html.prototype.stylemap = {
+      bold: "font-weight"
+    , underline: "text-decoration"
+    , color: "color"
+    , background: "background"
+  }
 
-    var stylemap =
-      { bold: "font-weight"
-      , underline: "text-decoration"
-      , color: "color"
-      , background: "background"
-      }
-
-    function style() {
-      var key, val, style = []
-      for (var key in props) {
-        val = props[key]
-        if (!val) continue
-        if (val == true) {
-          style.push(stylemap[key] + ':' + key)
-        } else {
-          style.push(stylemap[key] + ':' + val)
-        }
-      }
-      return style.join(';')
-    }
-
-
-    function tag(code) {
-      var i
-        , tag = ''
-        , n = ansi2html.table[code]
-
-      if (open) tag += '</span>'
-      open = false
-
-      if (n) {
-        for (i in n) props[i] = n[i]
-        tag += '<span style="' + style() + '">'
-        open = true
+  ansi2html.prototype.style = function style () {
+    var key, val, style = [];
+    for (var key in this.props) {
+      val = this.props[key];
+      if (!val) continue
+      if (val == true) {
+        style.push(this.stylemap[key] + ':' + key)
       } else {
-        props = {}
+        style.push(this.stylemap[key] + ':' + val)
       }
+    }
+    return style.join(';');
+  }
 
-      return tag
+
+  ansi2html.prototype.tag = function tag (code) {
+    var i
+      , tag = ''
+      , n = this.table[code];
+
+    if (this.open) {
+      tag += '</span>';
+      this.open = false;
     }
 
-    return str.replace(/\[(\d+;)?(\d+)+m/g, function(match, b1, b2) {
-      var i, code, res = ''
-      for (i = 1; i < arguments.length - 2; i++) {
-        if (!arguments[i]) continue
-        code = parseInt(arguments[i])
+    if (n) {
+      for (i in n) this.props[i] = n[i];
+      tag += '<span style="' + this.style() + '">';
+      this.open = true;
+    } else {
+      props = {};
+    }
 
-        res += tag(code)
-      }
-      return res
-    }) + tag()
+    return tag;
   }
+
+  ansi2html.prototype.render = function render () {
+    return this.str.replace(/\[(\d+;)?(\d+)+m/g, function(match, b1, b2) {
+      var i, code, res = '';
+      for (i = 1; i < arguments.length - 2; i++) {
+        if (!arguments[i]) continue;
+        code = parseInt(arguments[i]);
+        res += this.tag(code);
+      }
+      return res;
+    }.bind(this)) + this.tag();
+  };
 
   /* not implemented:
    *   italic
@@ -67,7 +71,7 @@
    *   invert
    *   strikethrough
    */
-  ansi2html.table =
+  ansi2html.prototype.table =
   { 0: null
   , 1: { bold: true }
   , 3: { italic: true }
@@ -101,6 +105,6 @@
   , 49: { background: null }
   }
 
-  declare('ansi2html', ansi2html)
-})()
+  declare('ansi2html', ansi2html);
+})();
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,13 +15,20 @@
     , underline: "text-decoration"
     , color: "color"
     , background: "background"
+  };
+  
+  ansi2html.prototype.classmap = {
+      color: 'fg'
+    , background: 'bg'
+    , bold: 'bold'
+    , underline: 'ul'
   }
 
   ansi2html.prototype.style = function style () {
     var key, val, style = [];
     for (var key in this.props) {
       val = this.props[key];
-      if (!val) continue
+      if (!val) continue;
       if (val == true) {
         style.push(this.stylemap[key] + ':' + key)
       } else {
@@ -31,8 +38,21 @@
     return style.join(';');
   }
 
+  ansi2html.prototype.classGen = function () {
+    var key, val, classes = [];
+    for (key in this.props) {
+      val = this.props[key];
+      if (!val) continue;
+      if (val == true)
+        classes.push(this.classmap[key]);
+      else {
+        classes.push(this.classmap[key] + '_' + val);
+      }
+    }
+    return classes.join(' ');
+  }
 
-  ansi2html.prototype.tag = function tag (code) {
+  ansi2html.prototype.tag = function tag (code, use_class) {
     var i
       , tag = ''
       , n = this.table[code];
@@ -44,7 +64,11 @@
 
     if (n) {
       for (i in n) this.props[i] = n[i];
-      tag += '<span style="' + this.style() + '">';
+      if (use_class === true) {
+        tag += '<span class="ansi ' + this.classGen() + '">';
+      } else {
+        tag += '<span style="' + this.style() + '">';
+      }
       this.open = true;
     } else {
       props = {};
@@ -53,16 +77,16 @@
     return tag;
   }
 
-  ansi2html.prototype.render = function render () {
+  ansi2html.prototype.render = function render (opts) {
     return this.str.replace(/\[(\d+;)?(\d+)+m/g, function(match, b1, b2) {
       var i, code, res = '';
       for (i = 1; i < arguments.length - 2; i++) {
         if (!arguments[i]) continue;
         code = parseInt(arguments[i]);
-        res += this.tag(code);
+        res += this.tag(code, opts.use_class);
       }
       return res;
-    }.bind(this)) + this.tag();
+    }.bind(this)) + this.tag(undefined, opts.use_class);
   };
 
   /* not implemented:

--- a/test/index.js
+++ b/test/index.js
@@ -3,9 +3,9 @@ var ansi2html = require('../lib/')
   , assert = require('assert')
 
 function makeBatchFromTestCases(testCases) {
-  function makeTest(input, expected) {
-    var test = { topic: function() { return (new ansi2html(input)).render(); } }
-    test['we get "' + expected + '"'] = function(topic) { assert.equal(topic, expected) }
+  function makeTest(input, args) {
+    var test = { topic: function() { return (new ansi2html(args[0])).render({use_class: args[2]}); } }
+    test['we get "' + args[1] + '"'] = function(topic) { assert.equal(topic, args[1]) }
     return test
   }
 
@@ -16,15 +16,21 @@ function makeBatchFromTestCases(testCases) {
   }
   return batch
 }
-
+// name : [ input, output, external_styles ]
 var suite = vows.describe('ansi2html')
 suite.addBatch(makeBatchFromTestCases(
-{ 'testString': 'testString'
-, 'test[0mString': 'testString'
-, 'test[32mString': 'test<span style="color:green">String</span>'
-, 'test[1mBold[32mGreen[31mRed[0mNone': 'test<span style="font-weight:bold">Bold</span><span style="font-weight:bold;color:green">Green</span><span style="font-weight:bold;color:red">Red</span>None'
-, 'test[31mRed[1mBold[39mString': 'test<span style="color:red">Red</span><span style="color:red;font-weight:bold">Bold</span><span style="font-weight:bold">String</span>'
-, 'test[42mGreenBG': 'test<span style="background:green">GreenBG</span>'
+{
+    'inline_equal': ['testString', 'testString', false]
+  , 'inline_null': ['test[0mString', 'testString', false]
+  , 'inline_green': ['test[32mString', 'test<span style="color:green">String</span>', false]
+  , 'inline_boldcolour': ['test[1mBold[32mGreen[31mRed[0mNone', 'test<span style="font-weight:bold">Bold</span><span style="font-weight:bold;color:green">Green</span><span style="font-weight:bold;color:red">Red</span>None', false]
+  , 'inline_colourbold': ['test[31mRed[1mBold[39mString', 'test<span style="color:red">Red</span><span style="color:red;font-weight:bold">Bold</span><span style="font-weight:bold">String</span>', false]
+  , 'inline_background': ['test[42mGreenBG', 'test<span style="background:green">GreenBG</span>', false]
+  , 'external_equal': ['testString', 'testString', true]
+  , 'external_green': ['test[32mString', 'test<span class="ansi fg_green">String</span>', true]
+  , 'external_boldcolour': ['test[1mBold[32mGreen[31mRed[0mNone', 'test<span class="ansi bold">Bold</span><span class="ansi bold fg_green">Green</span><span class="ansi bold fg_red">Red</span>None', true]
+  , 'external_colourbold': ['test[31mRed[1mBold[39mString', 'test<span class="ansi fg_red">Red</span><span class="ansi fg_red bold">Bold</span><span class="ansi bold">String</span>', true]
+  , 'external_background': ['test[42mGreenBG', 'test<span class="ansi bg_green">GreenBG</span>', true]
 }))
 suite.export(module)
 

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ var ansi2html = require('../lib/')
 
 function makeBatchFromTestCases(testCases) {
   function makeTest(input, expected) {
-    var test = { topic: function() { return ansi2html(input) } }
+    var test = { topic: function() { return (new ansi2html(input)).render(); } }
     test['we get "' + expected + '"'] = function(topic) { assert.equal(topic, expected) }
     return test
   }


### PR DESCRIPTION
Adds an option to render() to allow output of HTML with class attributes rather that style attributes. Will allows for better integration with peoples sites/CSS/etc.
