### PR TITLE
Support [m escape sequence.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,12 +49,12 @@
       return tag
     }
 
-    return str.replace(/\[(\d+;)?(\d+)+m/g, function(match, b1, b2) {
+    return str.replace(/\[(\d+;)?(\d+)*m/g, function(match, b1, b2) {
       var i, code, res = ''
+      if (b2 == '' || b2 == null) b2 = '0'
       for (i = 1; i < arguments.length - 2; i++) {
         if (!arguments[i]) continue
         code = parseInt(arguments[i])
-
         res += tag(code)
       }
       return res

--- a/test/index.js
+++ b/test/index.js
@@ -25,6 +25,8 @@ suite.addBatch(makeBatchFromTestCases(
 , 'test[1mBold[32mGreen[31mRed[0mNone': 'test<span style="font-weight:bold">Bold</span><span style="font-weight:bold;color:green">Green</span><span style="font-weight:bold;color:red">Red</span>None'
 , 'test[31mRed[1mBold[39mString': 'test<span style="color:red">Red</span><span style="color:red;font-weight:bold">Bold</span><span style="font-weight:bold">String</span>'
 , 'test[42mGreenBG': 'test<span style="background:green">GreenBG</span>'
+, 'test[32mString[0mNone': 'test<span style="color:green">String</span>None'
+, 'test[32mString[mNone': 'test<span style="color:green">String</span>None'
 }))
 suite.export(module)
 


### PR DESCRIPTION
Some software, like Git uses \e[m instead of \e[0m to clear the character attributes.

This commit makes ansi2html able to pass it, as well as a simple test case.
