### PR TITLE
Add bin/ansi2html for converting ansi from stdin to html

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Convert text with ANSI escape sequences to styled HTML.
 ```
 test[1mBold[32mGreen[31mRed[0mNone
 ```
-    
+
 becomes
 
 ```html
@@ -33,6 +33,12 @@ In the browser:
 <script type="text/javascript">
 document.getElementById('test').innerHTML = ansi2html("test[1mBold")
 </script>
+```
+
+In the terminal:
+
+```bash
+git log --color | ansi2html > result.html
 ```
 
 That's right, ansi2html.js works in Node *and* in the browser, in more or less the same way.

--- a/bin/ansi2html
+++ b/bin/ansi2html
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+var data = ''
+  , ansi2html = require('../lib/index.js')
+
+process.stdin.on('data', function(chunk) {
+  data += chunk
+})
+
+process.stdin.on('end', function() {
+  // strip escape characters (e.g. git log --color | ansi2html)
+  console.log(ansi2html(data.replace(/\u001B/g, '')))
+})
+
+process.stdin.resume()

--- a/package.json
+++ b/package.json
@@ -3,15 +3,18 @@
 , "description": "Convert text with ANSI escape sequences to HTML markup"
 , "version": "0.0.0"
 , "homepage": "https://github.com/agnoster/ansi2html"
-, "repository": 
+, "bin":
+  { "ansi2html": "./bin/ansi2html"
+  }
+, "repository":
   { "url": ""
   }
 , "main": "./lib/"
-, "engines": 
+, "engines":
   { "node": ">0.4"
   }
 , "dependencies": {}
-, "devDependencies": 
+, "devDependencies":
   { "vows": "~0.5.8"
   }
 , "scripts":


### PR DESCRIPTION
I tried to follow your style conventions. If you accept this PR, could you also bump up the npm version (e.g. `npm version patch`, `git push`, `npm publish`? I think the repo link on npm is outdated..

Here is a usage example, btw: `git log --color  | ansi2html | marked > diff.html`

I'm using marked to convert the paragraphs to html.
